### PR TITLE
[Feature] Implement VMPilot SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 build/
 .vscode/
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ endif ()
 # add dependencies
 include(cmake/CPM.cmake)
 CPMAddPackage("gh:nlohmann/json@3.11.2")
+
 # Set linux openssl path
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,14 @@ endif ()
 # add dependencies
 include(cmake/CPM.cmake)
 CPMAddPackage("gh:nlohmann/json@3.11.2")
+# Set linux openssl path
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    set(OPENSSL_ROOT_DIR /opt/homebrew/opt/openssl)
+elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(OPENSSL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/installed/x64-windows)  
+endif()
 
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Experience the power of VMPilot and fortify your software against reverse engine
 - Supporting C++17 or higher compiler
 - OpenSSL 3.1.1
 
+### Underlining Dependencies
+It would be fetched automatically by CPM(CMake Package Manager) during the build process.
+- [nlohmann/json](https://github.com/nlohmann/json)
+- [avast/retdec](https://github.com/avast/retdec) for SDK
+
 ## Optional Dependencies
 - [Ninja](https://github.com/ninja-build/ninja)
 - [mold](https://github.com/rui314/mold)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Experience the power of VMPilot and fortify your software against reverse engine
 # Dependencies
 - [CMake](https://cmake.org/download/) (3.26 or higher)
 - Supporting C++17 or higher compiler
+- OpenSSL 3.1.1
 
 ## Optional Dependencies
 - [Ninja](https://github.com/ninja-build/ninja)

--- a/runtime/dump_optable.cpp
+++ b/runtime/dump_optable.cpp
@@ -9,8 +9,9 @@ int main() {
     auto ot_gen = VMPilot::Common::Opcode_table_generator("test");
     auto runtime_table = ot_gen.Generate();
     auto buildtime_table = ot_gen.Get_RealOp_to_OID();
+#ifdef DEBUG
     auto secret_conv = ot_gen.GetOID_to_OI();
-
+#endif
     nlohmann::json j;
     j["runtime_table"] = nlohmann::json::array();
     j["buildtime_table"] = nlohmann::json::array();
@@ -32,7 +33,7 @@ int main() {
         };
         j["runtime_table"].push_back(entry);
     }
-
+#ifdef DEBUG
     // Loop over the secret conversion table
     for (const auto& [oid, oi] : secret_conv) {
         nlohmann::json entry = {
@@ -41,7 +42,7 @@ int main() {
         };
         j["secret_conversion_table"].push_back(entry);
     }
-
+#endif
     std::cout << j.dump(4) << std::endl;
 
     return 0;

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -1,0 +1,20 @@
+set (INCLUDE_DIRS 
+    ${INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+set (TARGET_NAME VMPilot_SDK)
+
+# Add the source files
+set (SRC_FILES ${SRC_FILES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/bytecode_compiler.cpp
+)
+
+set (LIBS ${LIBS} opcode_table)
+
+include_directories(${INCLUDE_DIRS})
+set (MAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+
+add_executable (${TARGET_NAME} ${SRC_FILES} ${MAIN_FILE})
+
+target_link_libraries(${TARGET_NAME} ${LIBS})

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -5,6 +5,8 @@ set (INCLUDE_DIRS
 
 set (TARGET_NAME VMPilot_SDK)
 
+CPMAddPackage("gh:avast/retdec@5.0")
+
 # Add the source files
 set (SRC_FILES ${SRC_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/bytecode_compiler.cpp

--- a/sdk/include/bytecode_compiler.hpp
+++ b/sdk/include/bytecode_compiler.hpp
@@ -1,0 +1,6 @@
+#ifndef __SDK_BYTECODE_COMPILER_HPP__
+#define __SDK_BYTECODE_COMPILER_HPP__
+
+
+
+#endif

--- a/sdk/main.cpp
+++ b/sdk/main.cpp
@@ -1,0 +1,5 @@
+#include <bytecode_compiler.hpp>
+
+int main() {
+    return 0;
+}

--- a/sdk/src/bytecode_compiler.cpp
+++ b/sdk/src/bytecode_compiler.cpp
@@ -1,0 +1,1 @@
+#include <bytecode_compiler.hpp>


### PR DESCRIPTION
This commit squashes multiple commits into a single cohesive feature commit.
The following changes are included:

- Added .DS_Store to .gitignore
- Set Linux and macOS OpenSSL paths in CMakeLists.txt
- Added OpenSSL 3.1.1 as an underlying dependency in README.md
- Added nlohmann/json and avast/retdec as new dependencies in README.md
- Conditional compilation and secret conversion table in runtime/dump_optable.cpp
- Added bytecode_compiler.hpp, main.cpp, and bytecode_compiler.cpp to the SDK
